### PR TITLE
Revert updating acorn dependency to @8

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nyc": "^15.1.0"
   },
   "dependencies": {
-    "acorn": "^8.0.4",
+    "acorn": "^6.4.1",
     "caporal": "1.4.0",
     "glob": "^7.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-check",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Checks the EcamScript version of .js glob against a specified version of EcamScript with a shell command",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Fixes

ATM there's a bug where if you run `es-check es5` on a file which contains `char` you'll get an error for char being a reserved name.
However, char is a reserved name for es3 and not es5. This bug happens only on 5.1.3.

## Proposed Changes

`acorn` =>  back to 6.4.1


