### PR TITLE
fix: logger for a successful ES-Check run changed from error log to info log

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ prog
       })
       process.exit(1)
     }
-    logger.error(`ES-Check: there were no ES version matching errors!  🎉`)
+    logger.info(`ES-Check: there were no ES version matching errors!  🎉`)
   })
 
 prog.parse(argsArray)


### PR DESCRIPTION
## Fixes

- Change the log level for a successful ES-Check run from *error* to *info*, as this message is not an error indication.



----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
