### PR TITLE
Fix not option and add glob

### DIFF
--- a/.escheckrc
+++ b/.escheckrc
@@ -1,4 +1,5 @@
 {
   "ecmaVersion": "es5",
-  "files": "./tests/es5.js"
+  "files": "./tests/es5.js",
+  "not": "./tests/skipped/*"
 }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ index.js es-check <ecmaVersion> [files...]
 **Not**
 
 ```sh
---not=folderName1,folderName2 An array of file/folder names that you would like to ignore. Defaults to `[]`.
+--not=folderName1,folderName2 An array of file/folder names or globs that you would like to ignore. Defaults to `[]`.
 ```
 
 ### Global Options
@@ -165,7 +165,8 @@ Here's an example of what an `.escheckrc` file will look like:
 {
   "ecmaVersion": "es6",
   "module": false,
-  "files": "./dist/**/*.js"
+  "files": "./dist/**/*.js",
+  "not": ["./dist/skip/*.js"]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ prog
     const files = args.files.length ? args.files : [].concat(config.files)
     const esmodule = options.module ? options.module : config.module
     const allowHashBang = options.allowHashBang ? options.allowHashBang : config.allowHashBang
-    const pathsToIgnore = options.not ? options.not : config.not
+    const pathsToIgnore = options.not.length ? options.not : [].concat(config.not)
 
     if (!expectedEcmaVersion) {
       logger.error(
@@ -122,10 +122,19 @@ prog
     const errArray = []
     const globOpts = { nodir: true }
     const acornOpts = { ecmaVersion, silent: true }
+
+    const expandedPathsToIgnore = pathsToIgnore.reduce((result, path) => {
+      if (path.includes('*')) {
+        return result.concat(glob.sync(path, globOpts))
+      } else {
+        return result.concat(path)
+      }
+    }, [])
+
     const filterForIgnore = (globbedFiles) => {
-      if (pathsToIgnore && pathsToIgnore.length > 0) {
+      if (expandedPathsToIgnore && expandedPathsToIgnore.length > 0) {
         const filtered = globbedFiles.filter(
-          (filePath) => !pathsToIgnore.some((ignoreValue) => filePath.includes(ignoreValue)),
+          (filePath) => !expandedPathsToIgnore.some((ignoreValue) => filePath.includes(ignoreValue)),
         )
         return filtered
       }

--- a/test.js
+++ b/test.js
@@ -116,36 +116,9 @@ it('👌 Es Check should read from an .escheckrc file for config', (done) => {
   })
 })
 
-it('👌  Es Check skips folders included in the not flag (non-glob)', (done) => {
-  exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules', (err, stdout, stderr) => {
-    if (err) {
-      console.error(err.stack)
-      console.error(stdout.toString())
-      console.error(stderr.toString())
-      done(err)
-      return
-    }
-    done()
-  })
-})
-
-it('👌  Es Check skips folders included in the not flag (glob)', (done) => {
-  exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules/*', (err, stdout, stderr) => {
-    if (err) {
-      console.error(err.stack)
-      console.error(stdout.toString())
-      console.error(stderr.toString())
-      done(err)
-      return
-    }
-    done()
-  })
-})
-
-it('👌  Es Check skips folders included in the not flag (mixed glob & not-glob)', (done) => {
-  exec(
-    'node index.js es5 ./tests/es5.js ./tests/modules/* ./tests/passed/* --not=./tests/passed,./tests/modules/*',
-    (err, stdout, stderr) => {
+describe('Es Check skips folders and files included in the not flag', () => {
+  it('👌  non-glob', (done) => {
+    exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules', (err, stdout, stderr) => {
       if (err) {
         console.error(err.stack)
         console.error(stdout.toString())
@@ -154,19 +127,48 @@ it('👌  Es Check skips folders included in the not flag (mixed glob & not-glob
         return
       }
       done()
-    },
-  )
-})
-
-it('👌  Es Check skips folders included in the not option in .escheckrc', (done) => {
-  exec('node index.js es5 ./tests/es5.js ./tests/skipped/es6-skipped.js', (err, stdout, stderr) => {
-    if (err) {
-      console.error(err.stack)
-      console.error(stdout.toString())
-      console.error(stderr.toString())
-      done(err)
-      return
-    }
-    done()
+    })
+  })
+  
+  it('👌  glob', (done) => {
+    exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules/*', (err, stdout, stderr) => {
+      if (err) {
+        console.error(err.stack)
+        console.error(stdout.toString())
+        console.error(stderr.toString())
+        done(err)
+        return
+      }
+      done()
+    })
+  })
+  
+  it('👌  mixed glob & non-glob', (done) => {
+    exec(
+      'node index.js es5 ./tests/es5.js ./tests/modules/* ./tests/passed/* --not=./tests/passed,./tests/modules/*',
+      (err, stdout, stderr) => {
+        if (err) {
+          console.error(err.stack)
+          console.error(stdout.toString())
+          console.error(stderr.toString())
+          done(err)
+          return
+        }
+        done()
+      },
+    )
+  })
+  
+  it('👌  .escheckrc', (done) => {
+    exec('node index.js es5 ./tests/es5.js ./tests/skipped/es6-skipped.js', (err, stdout, stderr) => {
+      if (err) {
+        console.error(err.stack)
+        console.error(stdout.toString())
+        console.error(stderr.toString())
+        done(err)
+        return
+      }
+      done()
+    })
   })
 })

--- a/test.js
+++ b/test.js
@@ -116,8 +116,50 @@ it('👌 Es Check should read from an .escheckrc file for config', (done) => {
   })
 })
 
-it('👌  Es Check skips versions included in the not flag', (done) => {
-  exec('node index.js es6 ./tests/passed/*.js --module --not=skipped,passed', (err, stdout, stderr) => {
+it('👌  Es Check skips folders included in the not flag (non-glob)', (done) => {
+  exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules', (err, stdout, stderr) => {
+    if (err) {
+      console.error(err.stack)
+      console.error(stdout.toString())
+      console.error(stderr.toString())
+      done(err)
+      return
+    }
+    done()
+  })
+})
+
+it('👌  Es Check skips folders included in the not flag (glob)', (done) => {
+  exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules/*', (err, stdout, stderr) => {
+    if (err) {
+      console.error(err.stack)
+      console.error(stdout.toString())
+      console.error(stderr.toString())
+      done(err)
+      return
+    }
+    done()
+  })
+})
+
+it('👌  Es Check skips folders included in the not flag (mixed glob & not-glob)', (done) => {
+  exec(
+    'node index.js es5 ./tests/es5.js ./tests/modules/* ./tests/passed/* --not=./tests/passed,./tests/modules/*',
+    (err, stdout, stderr) => {
+      if (err) {
+        console.error(err.stack)
+        console.error(stdout.toString())
+        console.error(stderr.toString())
+        done(err)
+        return
+      }
+      done()
+    },
+  )
+})
+
+it('👌  Es Check skips folders included in the not option in .escheckrc', (done) => {
+  exec('node index.js es5 ./tests/es5.js ./tests/skipped/es6-skipped.js', (err, stdout, stderr) => {
     if (err) {
       console.error(err.stack)
       console.error(stdout.toString())


### PR DESCRIPTION
## Fixes

- Fixes #49 

## Proposed Changes

- Also, update `not` option to accept globs. Not necessary for this fix, but accepting globs seems more consistent with the `files` option and it was easy enough to add support for without breaking the existing handling.

