### PR TITLE
fix: default config.not to empty array before concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ prog
     const files = args.files.length ? args.files : [].concat(config.files)
     const esmodule = options.module ? options.module : config.module
     const allowHashBang = options.allowHashBang ? options.allowHashBang : config.allowHashBang
-    const pathsToIgnore = options.not.length ? options.not : [].concat(config.not)
+    const pathsToIgnore = options.not.length ? options.not : [].concat(config.not || [])
 
     if (!expectedEcmaVersion) {
       logger.error(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-check",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Checks the EcamScript version of .js glob against a specified version of EcamScript with a shell command",
   "main": "index.js",
   "files": [
@@ -87,7 +87,7 @@
       ]
     }
   },
-   "husky": {
+  "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "post-checkout": "if [[ $HUSKY_GIT_PARAMS =~ 1$ ]]; then yarn; fi",

--- a/test.js
+++ b/test.js
@@ -129,7 +129,7 @@ describe('Es Check skips folders and files included in the not flag', () => {
       done()
     })
   })
-  
+
   it('👌  glob', (done) => {
     exec('node index.js es5 ./tests/es5.js ./tests/modules/* --not=./tests/modules/*', (err, stdout, stderr) => {
       if (err) {
@@ -142,7 +142,7 @@ describe('Es Check skips folders and files included in the not flag', () => {
       done()
     })
   })
-  
+
   it('👌  mixed glob & non-glob', (done) => {
     exec(
       'node index.js es5 ./tests/es5.js ./tests/modules/* ./tests/passed/* --not=./tests/passed,./tests/modules/*',
@@ -158,7 +158,7 @@ describe('Es Check skips folders and files included in the not flag', () => {
       },
     )
   })
-  
+
   it('👌  .escheckrc', (done) => {
     exec('node index.js es5 ./tests/es5.js ./tests/skipped/es6-skipped.js', (err, stdout, stderr) => {
       if (err) {


### PR DESCRIPTION
## Fixes

- Fixes #58 

## Proposed Changes

Before: `const pathsToIgnore = options.not.length ? options.not : [].concat(config.not)`

`pathsToIgnore` could end up as `[undefined]` when config file is missing or without `"not"` which later causes `path.includes("*")` to error.

After:  `const pathsToIgnore = options.not.length ? options.not : [].concat(config.not || [])`

Simply falls back from `config.not` to an empty array. I would have liked to write a regression test but I think ideally we would have the option to specify a config file (or not provide one). I think that goes beyond the scope of this immediate fix though. Alternative suggestions welcome though of course!

EDIT: I have tested the fix by removing `"not"` from `.escheckrc` to repro the issue and after applying the fix, all tests pass except one that expects `"not"` to appear in the config file, which is expected.
