### PR TITLE
fix: no lockfile check for pnpm node gh action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install -g pnpm
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - run: pnpm run lint:ci
       - run: pnpm run test


### PR DESCRIPTION
## Fixes

- Fixes `pnpm` dependabot lockfile issue'

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
