### PR TITLE
Use "overrides" to help npm version 8.3 and newer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
   "resolutions": {
     "ansi-regex": "5.0.1"
   },
+  "overrides": {
+    "ansi-regex": "5.0.1",
+    "@caporal/core@^2.0.2": {
+      "@types/lodash": "^4.14.149",
+      "lodash": "^4.17.21"
+    }
+  },
   "scripts": {
     "chore:delete-branch": "if git show-ref --quiet refs/heads/chore-changelog; then git branch -D chore-changelog; fi",
     "chore:branch": "git checkout -b chore-changelog",


### PR DESCRIPTION
The "overrides" flag allows to make specific changes to (sub-)dependencies (see [1]). It is supported by npm 8.3 and newer (see [2]).

With this change after an "npm i" "npm audit" will print `found 0 vulnerabilities`. Previously it printed `11 vulnerabilities (9 moderate, 2 high)`.

This fixes #123 for `npm`.

[1] https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides
[2] https://github.com/npm/cli/releases/tag/v8.3.0