### PR TITLE
chore(setup): update Husky usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "scripts": {
     "commit": "git-cz",
     "commit-msg": "commitlint --edit $1",
-    "husky-setup": "path-exists .husky/commit-msg || (husky install && pnpm husky-setup:commit-msg && pnpm husky-setup:post-merge && pnpm husky-setup:pre-commit)",
-    "husky-setup:commit-msg": "npx husky add .husky/commit-msg 'pnpm run commit-msg'",
-    "husky-setup:post-merge": "npx husky add .husky/post-merge 'pnpm run setup'",
-    "husky-setup:pre-commit": "npx husky add .husky/pre-commit 'pnpm run pre-commit'",
+    "husky-setup": "path-exists .husky/commit-msg || (husky init && pnpm husky-setup:commit-msg && pnpm husky-setup:post-merge && pnpm husky-setup:pre-commit)",
+    "husky-setup:commit-msg": "echo 'pnpm run commit-msg' > .husky/commit-msg",
+    "husky-setup:post-merge": "echo 'pnpm run setup' > .husky/post-merge",
+    "husky-setup:pre-commit": "echo 'pnpm run pre-commit' > .husky/pre-commit",
     "lint": "eslint index.js --fix",
     "lint:ci": "eslint index.js",
     "pre-commit": "pnpm lint && pnpm test",
-    "prepare": "is-ci || pnpm husky-setup",
+    "prepare": "husky",
     "prepublishOnly": "pnpm test",
     "release": "release-it",
     "report:coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
@@ -104,5 +104,6 @@
     "github": {
       "release": true
     }
-  }
+  },
+  "packageManager": "pnpm@8.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,5 @@
     "github": {
       "release": true
     }
-  },
-  "packageManager": "pnpm@8.1.1"
+  }
 }


### PR DESCRIPTION
## Proposed Changes

Found while working on #197, pulled out to not force coupling.

- Updates to using [new Husky v9 commands](https://github.com/typicode/husky/releases/tag/v9.0.1)
Deprecated `install` and `add` commands were causing lifecycle events to fail. Verified that hooks are still installed and functional after these changes.

- Adds `packageManager` entry to `package.json` to enable [Corepack](https://nodejs.org/api/corepack.html) compatibility
References same version as referenced in setup/env. For Corepack users this will prompt automatic installation of the correct version, and will be noop for everyone else.