### PR TITLE
feat(config): allow defining files via flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,20 @@ index.js es-check <ecmaVersion> [files...]
 **Not**
 
 ```sh
---not=folderName1,folderName2 An array of file/folder names or globs that you would like to ignore. Defaults to `[]`.
+
+--not=target1,target2 An array of file/folder names or globs that you would like to ignore. Defaults to `[]`.
+
 ```
+
+**Files**
+
+```sh
+
+--files=target1,target2 An array of file/folder names or globs to test the ECMAScript version against. Alias of [...files] argument.
+
+```
+
+⚠️ **NOTE:** This is primarily intended as a way to override the `files` setting in the `.escheckrc` file for specific invocations. Setting both the `[...files]` argument and `--files` flag is an error.
 
 ### Global Options
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ program
   .argument('[files...]', 'a glob of files to to test the EcmaScript version against')
   .option('--module', 'use ES modules')
   .option('--allow-hash-bang', 'if the code starts with #! treat it as a comment')
+  .option('--files <files>', 'a glob of files to to test the EcmaScript version against (alias for [files...])')
   .option('--not <files>', 'folder or file names to skip')
   .option('--no-color', 'disable use of colors in output')
   .option('-v, --verbose', 'verbose mode: will also output debug messages')
@@ -53,6 +54,11 @@ program
 
     const configFilePath = path.resolve(process.cwd(), '.escheckrc')
 
+    if (filesArg && filesArg.length && options.files) {
+      logger.error('Cannot pass in both [files...] argument and --files flag at the same time!')
+      process.exit(1)
+    }
+
     /**
      * @note
      * Check for a configuration file.
@@ -61,7 +67,8 @@ program
      */
     const config = fs.existsSync(configFilePath) ? JSON.parse(fs.readFileSync(configFilePath)) : {}
     const expectedEcmaVersion = ecmaVersionArg ? ecmaVersionArg : config.ecmaVersion
-    const files = filesArg && filesArg.length ? filesArg : [].concat(config.files)
+    const files =
+      filesArg && filesArg.length ? filesArg : options.files ? options.files.split(',') : [].concat(config.files)
     const esmodule = options.module ? options.module : config.module
     const allowHashBang = options.allowHashBang ? options.allowHashBang : config.allowHashBang
     const pathsToIgnore = options.not ? options.not.split(',') : [].concat(config.not || [])

--- a/test.js
+++ b/test.js
@@ -201,3 +201,35 @@ describe('Es Check skips folders and files included in the not flag', () => {
     })
   })
 })
+
+describe('Es Check supports the --files flag', () => {
+  it('🎉  Es Check should pass when checking a glob with es6 modules as es6 using the --files flag', (done) => {
+    exec('node index.js es6 --files=./tests/*.js', (err, stdout, stderr) => {
+      assert(stdout)
+      if (err) {
+        console.error(err.stack)
+        console.error(stdout.toString())
+        console.error(stderr.toString())
+        done(err)
+        return
+      }
+      done()
+    })
+  })
+
+  it('👌  Es Check should fail when checking a glob with es6 modules as es5 using the --files flag', (done) => {
+    exec('node index.js es5 --files=./tests/*.js', (err, stdout, stderr) => {
+      assert(err)
+      console.log(stdout)
+      done()
+    })
+  })
+
+  it('👌  Es Check should fail when given both spread files and --files flag', (done) => {
+    exec('node index.js es6 ./tests/*.js --files=./tests/*.js', (err, stdout, stderr) => {
+      assert(err)
+      console.log(stdout)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
## Fixes

- Fixes #197 

## Proposed Changes

- Adds the `--files` flag as an alias of the `[...files]` array to allow for easier overriding of `.escheckrc` files.