### PR TITLE
chore: udpates release-it commit msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     }
   },
   "release-it": {
+    "git": {
+      "commitMessage": "chore: release v${version}"
+    },
     "github": {
       "release": true
     }


### PR DESCRIPTION
## Fixes

- Fixes issue when releasing with release-it. The git tag creation step is failing b/c of the husky and the commit message that was being created

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
