### PR TITLE
feat: adds initial `fast-check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ benchmarks/test-files/
 benchmarks/test-files-*/
 
 dist/
+.browserslistrc-env
+.browserslistrc-legacy
+.browserslistrc-mixed
+.browserslistrc-modern
+.browserslistrc-old-edge

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Here's a comprehensive list of all available options:
 |--------|-------------|
 | `-V, --version` | Output the version number |
 | `--module` | Use ES modules (default: false) |
+| `--light` | Lightweight mode: 2-3x faster checking using pattern matching only (default: false) |
 | `--allowHashBang` | If the code starts with #! treat it as a comment (default: false) |
 | `--files <files>` | A glob of files to test the ECMAScript version against (alias for [files...]) |
 | `--not <files>` | Folder or file names to skip |
@@ -199,6 +200,12 @@ Once enabled, you can use tab completion for:
 
 ```sh
 es-check es6 './dist/**/*.js' --module
+```
+
+**Fast checking with light mode (2-3x faster):**
+
+```sh
+es-check es5 './dist/**/*.js' --light
 ```
 
 **Checking files with hash bang:**

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -106,6 +106,20 @@ In May 2025, we established initial benchmarks after adding extensive new featur
 
 On August 6, 2025, we implemented major performance optimizations based on the May benchmarks. The key improvements included eliminating double parsing by reusing the AST between syntax checking and feature detection, adding async file processing with configurable batch sizes, and optimizing glob operations. These changes resulted in es-check improving from 3.14x slower to 1.81x slower - a 42% performance gain while maintaining all features.
 
+#### January 2025 - Light Mode with fast-brake
+
+We integrated `fast-brake` for pattern-based checking and added a `--light` mode that provides 2-3x faster performance:
+
+| Tool | Average (ms) | Min (ms) | Max (ms) | Relative Performance |
+|------|-------------|----------|----------|----------------------|
+| are-you-es5 | 36.35 | 34.21 | 41.35 | 1x (fastest) |
+| acorn (direct) | 49.72 | 46.73 | 52.65 | 1.37x slower |
+| babel-parser | 76.18 | 59.52 | 120.70 | 2.10x slower |
+| **es-check-light** | **87.90** | **77.62** | **105.30** | **2.42x slower** |
+| es-check | 131.10 | 120.78 | 155.64 | 3.61x slower |
+
+The `--light` mode uses fast-brake's optimized pattern matching instead of full AST parsing, achieving near-parser speeds while still supporting ES3-ES2025, with more performance improvements to come.
+
 ##### Small Test Set (100 files) - August 2025
 | Tool | Average (ms) | Min (ms) | Max (ms) | Relative Performance |
 |------|-------------|----------|----------|----------------------|

--- a/benchmarks/compare-tools.js
+++ b/benchmarks/compare-tools.js
@@ -71,6 +71,24 @@ const tools = [
     }
   },
   {
+    name: 'es-check-light',
+    run: async (testFiles) => {
+      const startTime = performance.now();
+      try {
+        await execFileAsync('node', [
+          './index.js',
+          esVersion,
+          ...testFiles,
+          '--light',
+          '--silent'
+        ]);
+      } catch (error) {
+
+      }
+      return performance.now() - startTime;
+    }
+  },
+  {
     name: 'es-check-batch-10',
     run: async (testFiles) => {
       const startTime = performance.now();

--- a/detectFeatures.js
+++ b/detectFeatures.js
@@ -86,7 +86,10 @@ const detectFeatures = (code, ecmaVersion, sourceType, ignoreList = new Set(), o
     detectedFeatures = ast.features;
   } else {
     try {
-      detectedFeatures = fastBrake.detect(code);
+      const detectOptions = {
+        sourceType: sourceType || 'script'
+      };
+      detectedFeatures = fastBrake.detect(code, detectOptions);
     } catch (err) {
       const error = new Error(`Failed to parse code: ${err.message}`);
       error.type = 'ES-Check';

--- a/index.js
+++ b/index.js
@@ -586,6 +586,8 @@ async function runChecks(configs, loggerOrOptions) {
   
   if (isNodeAPI) {
     return { success: true, errors: [] };
+  } else {
+    process.exit(0);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ program
   .option('--config <path>', 'path to custom .escheckrc config file')
   .option('--batchSize <number>', 'number of files to process concurrently (0 for unlimited)', '0')
   .option('--noCache', 'disable file caching (caching is enabled by default)', false)
+  .option('--light', 'lightweight mode: faster checking with pattern matching only (skips full AST parsing)', false)
 
 async function loadConfig(customConfigPath) {
   const logger = createLogger();
@@ -182,6 +183,7 @@ program
         browserslistEnv: options.browserslistEnv !== undefined ? options.browserslistEnv : baseConfig.browserslistEnv,
         batchSize: options.batchSize !== undefined ? options.batchSize : baseConfig.batchSize,
         cache: options.noCache ? false : (baseConfig.cache !== undefined ? baseConfig.cache : true),
+        light: options.light !== undefined ? options.light : baseConfig.light,
       };
 
       if (ecmaVersionArg !== undefined) {
@@ -236,6 +238,7 @@ async function runChecks(configs, loggerOrOptions) {
     const checkFeatures = config.checkFeatures;
     const checkForPolyfills = config.checkForPolyfills;
     const checkBrowser = config.checkBrowser;
+    const lightMode = config.light;
     const ignoreFilePath = config.ignoreFile || config['ignore-file'];
 
     const ignoreFileExists = ignoreFilePath && fs.existsSync(ignoreFilePath);
@@ -475,10 +478,22 @@ async function runChecks(configs, loggerOrOptions) {
         logger.debug(`ES-Check: checking ${file}`)
       }
 
+      if (lightMode) {
+        const { parseLightMode } = require('./utils');
+        const { error: parseError } = await parseLightMode(code, ecmaVersion, esmodule, allowHashBang, file);
+        if (parseError) {
+          if (isDebug) {
+            logger.debug(`ES-Check: failed to parse file: ${file} \n - error: ${parseError.err}`)
+          }
+          return parseError;
+        }
+        return null;
+      }
+
       const needsFullAST = checkFeatures;
       const parserOptions = needsFullAST ? acornOpts : { ...acornOpts, locations: false, ranges: false, onComment: null };
       
-      const { ast, error: parseError } = parseCode(code, parserOptions, acorn, file);
+      const { ast, error: parseError } = parseCode(code, parserOptions, acorn, file, checkFeatures);
       if (parseError) {
         if (isDebug) {
           logger.debug(`ES-Check: failed to parse file: ${file} \n - error: ${parseError.err}`)

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "acorn-walk": "^8.3.4",
     "browserslist": "^4.23.3",
     "commander": "14.0.0",
+    "fast-brake": "^0.1.1",
     "fast-glob": "^3.3.3",
     "lilconfig": "^3.1.3",
     "source-map": "^0.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       commander:
         specifier: 14.0.0
         version: 14.0.0
+      fast-brake:
+        specifier: ^0.1.1
+        version: 0.1.1
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -133,7 +136,7 @@ importers:
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.23)
       astro:
-        specifier: ^5.12.8
+        specifier: ^5.13.1
         version: 5.13.1(@types/node@24.3.0)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.46.3)(supports-color@8.1.1)(typescript@5.8.3)(yaml@2.8.0)
       fuse.js:
         specifier: ^7.1.0
@@ -2568,6 +2571,9 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-brake@0.1.1:
+    resolution: {integrity: sha512-alUdFuQR7XlFq6NnV/6SXAspmFTuo+al12hrcivjPzomdck2MUFJ5bRc+F3BL4UHtVKEHKpp6LD0AD+e0v0QvA==}
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
@@ -7884,6 +7890,8 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-brake@0.1.1: {}
 
   fast-content-type-parse@2.0.1: {}
 


### PR DESCRIPTION
## Proposed Changes

This update adds a `--light` option which adds a little bit of improvement (more to come).
- Performance is improved by implementing [fast-brake](https://jeffry.in/fast-brake/), a tool specialized in fast failure and fast detection. This first pass it to get it all working with hopes to really speed es-check up

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
