### PR TITLE
chore: add pastoralist override metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,17 @@
   ],
   "resolutions": {
     "eslint-scope": "3.7.1"
+  },
+  "pastoralist": {
+    "appendix": {
+      "eslint-scope@3.7.1": {
+        "dependents": {
+          "es-check": "eslint-scope (unused override)"
+        },
+        "ledger": {
+          "addedDate": "2020-10-27T16:40:48-07:00"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds Pastoralist override metadata from a clean current-upstream run.

Metrics from the run:
- Upstream ref: `dollarshaveclub/es-check@master`
- Override/resolution entries: 1
- Package manifests scanned: 446
- Appendix entries added: 1

Note: this PR targets the yowainwright fork, not the upstream project.